### PR TITLE
Generate source maps on build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,6 @@ export default defineConfig({
     },
   },
   build: {
-    sourcemap: "hidden",
+    sourcemap: true,
   },
 });


### PR DESCRIPTION
**Changes**

Sets `build.sourcemap` field to true in vite's config. Note that we need to keep `sourceMappingURL` for Sentry.

Resolves AR-766.