### PR TITLE
Renamed Email to Public Identifier in profile page and user details

### DIFF
--- a/src/pages/AppProfile.vue
+++ b/src/pages/AppProfile.vue
@@ -31,7 +31,7 @@
             <span class="sub-heading-3">{{ name }}</span>
           </div>
           <div class="flex column details">
-            <span class="body-2">Email</span>
+            <span class="body-2">Public Identifier</span>
             <span class="sub-heading-3">{{ email }}</span>
           </div>
           <div class="flex column details" style="visibility: hidden">

--- a/src/pages/AppUsers.vue
+++ b/src/pages/AppUsers.vue
@@ -117,8 +117,8 @@
         >
           <div class="flex column" style="gap: 1vh">
             <span class="body-1" style="color: var(--text-grey)">
-              Email ID</span
-            >
+              Public Identifier
+            </span>
             <span class="sub-heading-3" style="color: var(--text-white)">
               {{ userLog.email }}
             </span>


### PR DESCRIPTION
Renamed 'Email' to 'Public Identifier' in profile page and user details popup. There are cases in Github SSO and Discord SSO where sometimes we don't get user's email as identifier, instead we get a unique numeric id and we use that for fetching/ generating keys.

ref: https://team-1624093970686.atlassian.net/browse/AR-856?atlOrigin=eyJpIjoiNjRmNWQ5MTVmYjhhNDI3NWFjOWY1NDA0OTc0NmQ3MWQiLCJwIjoiaiJ9