### PR TITLE
fix: Cancel button not working in profile details

### DIFF
--- a/src/pages/AppProfile.vue
+++ b/src/pages/AppProfile.vue
@@ -64,7 +64,7 @@
               variant="link"
               label="Cancel"
               :disabled="false"
-              @click="editOrganisationDetails = false"
+              @click="resetOrganisationDetails"
               style="color: #8d8d8d"
             />
             <v-button
@@ -96,7 +96,11 @@
               </div>
               <div class="flex column details">
                 <span class="body-2">Size</span>
-                <span class="body-3" style="text-transform: uppercase; letter-spacing: .1em;" v-if="organisationDetails.sizeErrorMessage">
+                <span
+                  class="body-3"
+                  style="text-transform: uppercase; letter-spacing: 0.1em"
+                  v-if="organisationDetails.sizeErrorMessage"
+                >
                   {{ organisationDetails.sizeErrorMessage }}
                 </span>
                 <span class="sub-heading-3" v-if="!editOrganisationDetails">
@@ -240,14 +244,19 @@ export default {
     email.value = store.getters.userInfo.email;
     const router = useRouter();
 
+    // Need this to maintain state of organisation details before editing
+    // onCancel we can revert organisationDetails to this state and onSave we can update this state
+    let organisationDetailsActualState = {};
+
     function onUpdateOrganization() {
       // Validation
-      const size = Number(organisationDetails.value.size)
+      const size = Number(organisationDetails.value.size);
       if (!Number.isFinite(size) || !Number.isSafeInteger(size) || size <= 0) {
-        organisationDetails.value.sizeErrorMessage = 'Invalid organization size.'
-        return
+        organisationDetails.value.sizeErrorMessage =
+          "Invalid organization size.";
+        return;
       }
-      organisationDetails.value.sizeErrorMessage = null
+      organisationDetails.value.sizeErrorMessage = null;
 
       // API Call
       try {
@@ -258,6 +267,7 @@ export default {
           region: organisationDetails.value.region,
         }).then((response) => {
           editOrganisationDetails.value = false;
+          organisationDetailsActualState = { ...organisationDetails.value };
         });
       } catch (e) {
         console.error(e);
@@ -272,6 +282,7 @@ export default {
           country: response.data.organization.country,
           region: response.data.organization.region,
         };
+        organisationDetailsActualState = { ...organisationDetails.value };
       });
     });
 
@@ -285,6 +296,15 @@ export default {
       router.push({ name: "Login" });
     }
 
+    function resetOrganisationDetails() {
+      editOrganisationDetails.value = false;
+      organisationDetails.value = { ...organisationDetailsActualState };
+
+      if (organisationDetails.value.sizeErrorMessage) {
+        organisationDetails.value.sizeErrorMessage = null;
+      }
+    }
+
     return {
       editPersonalDetails,
       editOrganisationDetails,
@@ -292,6 +312,7 @@ export default {
       password,
       onLogout,
       onUpdateOrganization,
+      resetOrganisationDetails,
       name,
       email,
     };


### PR DESCRIPTION
1. Added an object to hold current state of organisation details, i.e state of organisation details before editing
2. On Cancel we revert organisation details ref to the object holding the state
3. On save we update the object holding the current state with organisation details ref
4. Ref values are updated on edit, since our custom textfields use v-model for two way data binding