### PR TITLE
Allow UI Mode toggle if not saved on server

### DIFF
--- a/src/components/app-configure/auth/WebWallet.vue
+++ b/src/components/app-configure/auth/WebWallet.vue
@@ -40,6 +40,9 @@ const walletWebsiteDomain: ComputedRef<string> = computed(
 const hasUIMode: ComputedRef<boolean> = computed(
   () => store.getters.walletUIMode
 )
+const hasUIModeInGateway: ComputedRef<boolean> = computed(
+  () => store.getters.walletUIModeInGateway
+)
 
 function handleThemeChange(theme: Theme) {
   store.commit('updateSelectedTheme', theme.value)
@@ -95,7 +98,7 @@ function handleUIModeUpdate(value: boolean) {
               <VSwitch
                 :model-value="hasUIMode"
                 class="ui-mode-switch"
-                :disabled="hasUIMode"
+                :disabled="hasUIModeInGateway"
                 @update:model-value="handleUIModeUpdate"
               />
               <span class="body-1 font-300" :class="{ 'font-700': hasUIMode }"

--- a/src/components/app-configure/auth/WebWallet.vue
+++ b/src/components/app-configure/auth/WebWallet.vue
@@ -37,11 +37,9 @@ const selectedTheme: ComputedRef<Theme | undefined> = computed(() => {
 const walletWebsiteDomain: ComputedRef<string> = computed(
   () => store.getters.walletWebsiteDomain
 )
-const hasUIMode: ComputedRef<boolean> = computed(
-  () => store.getters.walletUIMode
-)
+const hasUIMode: ComputedRef<boolean> = computed(() => store.getters.hasUIMode)
 const hasUIModeInGateway: ComputedRef<boolean> = computed(
-  () => store.getters.walletUIModeInGateway
+  () => store.getters.hasUIModeInGateway
 )
 
 function handleThemeChange(theme: Theme) {

--- a/src/pages/AppConfigure.vue
+++ b/src/pages/AppConfigure.vue
@@ -35,7 +35,11 @@ function switchTab(tab: ConfigureTab) {
 async function handleSave() {
   store.commit('showLoader', 'Saving app config...')
   const appConfigRequestBody: AppConfig = store.getters.appConfigRequestBody
-  await updateApp(appConfigRequestBody)
+  const updatedApp = (await updateApp(appConfigRequestBody)).data
+  store.commit(
+    'updateWalletUIModeFromGateway',
+    updatedApp.app.wallet_type === WalletMode.UI
+  )
   await updateSmartContractTransactions(appConfigRequestBody)
   currentConfig = store.getters.appConfigRequestBody
   store.commit('hideLoader')
@@ -87,7 +91,7 @@ function handleCancel() {
     <ConfigureHeader />
     <VStack gap="2rem" class="container">
       <ConfigureSidebar :current-tab="currentTab" @switch-tab="switchTab" />
-      <router-view />
+      <RouterView />
     </VStack>
     <ConfigureFooter
       class="configure-footer"

--- a/src/pages/AppDashboard.vue
+++ b/src/pages/AppDashboard.vue
@@ -221,7 +221,7 @@ function copyAppId() {
 }
 
 function goToUsers() {
-  router.push('/users')
+  router.push({ name: 'Users' })
 }
 
 watch(

--- a/src/store/app.store.ts
+++ b/src/store/app.store.ts
@@ -178,9 +178,8 @@ const getters = {
   appId: (state: AppState) => state.appId,
   appAddress: (state: AppState) => state.appAddress,
   socialAuth: (state: AppState) => state.auth.social,
-  walletUIMode: (state: AppState) => state.auth.wallet.hasUIMode,
-  walletUIModeInGateway: (state: AppState) =>
-    state.auth.wallet.hasUIModeInGateway,
+  hasUIMode: (state: AppState) => state.auth.wallet.hasUIMode,
+  hasUIModeInGateway: (state: AppState) => state.auth.wallet.hasUIModeInGateway,
   walletWebsiteDomain: (state: AppState) => state.auth.wallet.websiteDomain,
   selectedTheme: (state: AppState) => state.auth.wallet.selectedTheme,
   selectedChain: (state: AppState) => state.access.selectedChain,

--- a/src/store/app.store.ts
+++ b/src/store/app.store.ts
@@ -112,6 +112,7 @@ type AppState = {
       websiteDomain: string
       selectedTheme: 'light' | 'dark'
       hasUIMode: boolean
+      hasUIModeInGateway: boolean
     }
     redirectUri: string
   }
@@ -153,6 +154,7 @@ function getDefaultAppState(): AppState {
         websiteDomain: '',
         selectedTheme: 'dark',
         hasUIMode: false,
+        hasUIModeInGateway: false,
       },
     },
     store: {
@@ -177,6 +179,8 @@ const getters = {
   appAddress: (state: AppState) => state.appAddress,
   socialAuth: (state: AppState) => state.auth.social,
   walletUIMode: (state: AppState) => state.auth.wallet.hasUIMode,
+  walletUIModeInGateway: (state: AppState) =>
+    state.auth.wallet.hasUIModeInGateway,
   walletWebsiteDomain: (state: AppState) => state.auth.wallet.websiteDomain,
   selectedTheme: (state: AppState) => state.auth.wallet.selectedTheme,
   selectedChain: (state: AppState) => state.access.selectedChain,
@@ -321,6 +325,9 @@ const mutations = {
   updateWalletUIMode(state: AppState, hasUIMode: boolean) {
     state.auth.wallet.hasUIMode = hasUIMode
   },
+  updateWalletUIModeFromGateway(state: AppState, hasUIModeInGateway: boolean) {
+    state.auth.wallet.hasUIModeInGateway = hasUIModeInGateway
+  },
   updateWalletWebsiteDomain(state: AppState, websiteDomain: string) {
     state.auth.wallet.websiteDomain = websiteDomain
   },
@@ -453,6 +460,10 @@ const actions = {
       }
 
       commit('updateWalletUIMode', currentApp.wallet_type === WalletMode.UI)
+      commit(
+        'updateWalletUIModeFromGateway',
+        currentApp.wallet_type === WalletMode.UI
+      )
     }
   },
   resetSettings({ commit }) {


### PR DESCRIPTION
Resolves [AR-2785](https://team-1624093970686.atlassian.net/browse/AR-2785).

## Changes

- Add `hasWalletUIModeInGateway` state variable to store the value of `wallet_type` present in server
- Add mutation and getter to that variable
- Disable switch if that state variable is true
- [refactor] Change route to users in Dashboard to named route

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
