### PR TITLE
Add storage and bandwidth usage, remaining and percentage values

### DIFF
--- a/src/pages/AppDashboard.vue
+++ b/src/pages/AppDashboard.vue
@@ -107,7 +107,7 @@ async function fetchAndPopulateUsersAndActions() {
     download: stats.data.actions?.download,
     upload: stats.data.actions?.upload,
     delete: stats.data.actions?.delete,
-    transfers: stats.data.actions?.transfers,
+    transfers: stats.data.actions?.ownership_change,
     share: stats.data.actions?.share,
     revoke: stats.data.actions?.revoke,
   }

--- a/src/pages/AppDashboard.vue
+++ b/src/pages/AppDashboard.vue
@@ -61,6 +61,7 @@ let storageData: number[] = []
 let bandwidthData: number[] = []
 const currentDate = moment()
 const quarters = ['Jan-Mar', 'Apr-Jun', 'Jul-Sept', 'Oct-Dec']
+const MAX_ALLOWED_APP_LIMIT: number = bytes('5 GB')
 
 let StorageChart: Chart
 let BandwidthChart: Chart
@@ -110,6 +111,24 @@ async function fetchAndPopulateUsersAndActions() {
     share: stats.data.actions?.share,
     revoke: stats.data.actions?.revoke,
   }
+
+  const storage: number = stats.data.actions?.storage
+  storageUsed.value = bytes(storage, {
+    unitSeparator: ' ',
+  })
+  storageUsedPercentage.value = (storage / MAX_ALLOWED_APP_LIMIT) * 100
+  storageRemaining.value = bytes(MAX_ALLOWED_APP_LIMIT - storage, {
+    unitSeparator: ' ',
+  })
+
+  const bandwidth: number = stats.data.actions?.bandwidth
+  bandwidthUsed.value = bytes(bandwidth, {
+    unitSeparator: ' ',
+  })
+  bandwidthUsedPercentage.value = (bandwidth / MAX_ALLOWED_APP_LIMIT) * 100
+  bandwidthRemaining.value = bytes(MAX_ALLOWED_APP_LIMIT - bandwidth, {
+    unitSeparator: ' ',
+  })
 }
 
 function updateChart(data: any[]) {


### PR DESCRIPTION
Resolves [AR-2954](https://team-1624093970686.atlassian.net/browse/AR-2954).

## Changes

- Add storage and bandwidth usage, remaining and percentage values
- Update `transfers` to `ownership_change`

## Screenshots

Before Changes
<img width="1509" alt="Screenshot 2022-06-10 at 12 59 55 PM" src="https://user-images.githubusercontent.com/24249988/173019134-bb883658-0443-47d6-affd-1a68813e07d8.png">
![Screenshot from 2022-06-10 17-01-15](https://user-images.githubusercontent.com/24249988/173055892-03f01e9d-9ecb-4581-b8f7-dc0b4fb00ac5.png)

After changes
![Screenshot from 2022-06-10 13-23-12](https://user-images.githubusercontent.com/24249988/173019224-6597f1d9-37e3-4bd9-bd85-e5935dfdf123.png)
![Screenshot from 2022-06-10 16-56-02](https://user-images.githubusercontent.com/24249988/173055817-06a79a86-1096-4447-a724-41a02d75bdbf.png)

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
