### PR TITLE
Shaloo/ar 3042 gh issue tmp

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Arcana Forum
+    url: https://forum.arcana.network/
+    about: Please ask your questions here.
+  - name: Arcana Discord
+    url: https://discord.gg/w6ej4FtqYS
+    about: Discuss about Arcana Network here.
+  - name: Telegram
+    url: https://t.me/ArcanaNetwork
+    about: Discuss about Arcana Network here.
+  - name: Twitter
+    url: https://twitter.com/arcananetwork
+    about: Discuss about Arcana Network here.

--- a/.github/ISSUE_TEMPLATE/dashboard_issue.yml
+++ b/.github/ISSUE_TEMPLATE/dashboard_issue.yml
@@ -1,0 +1,98 @@
+name: Arcana Dashboard Bug Report
+description: File an bug report for Arcana Dashboard
+title: "[Dashboard_Issue]: "
+labels: ["docs", "bug", "triage"]
+assignees:
+  - ajithranka
+body:
+  - type: markdown
+    attributes:
+      value: |
+
+        :wave:  **Hey, there!**
+        *Thank you for using Arcana Developer Dashboard.*
+        Help us timely address and prioritize your issue by going through this checklist and providing all the requisite issue details.
+  - type: checkboxes
+    id: issue-checklist
+    attributes:
+      label: Issue Checklist
+      description: Before you submit the issue, verify it is indeed a bug and not a question.
+      options:
+        - label: Is this something you can **debug and fix**? Send a pull request! Your contributions are valuable to us.
+          required: false
+        - label: Have a **usage question**? Ask your question on [StackOverflow](https://stackoverflow.com/search?q=%22arcana+network%22%2B%22XAR%22) or [Discord channel](https://discord.com/invite/w6ej4FtqYS). We use GitHub solely for bugs and feature enhancement requests.
+          required: false
+        - label: Is this a support query related to your specific use case? Contact us at [support@arcana.network](mailto:support@arcana.network).
+          required: false
+  - type: markdown
+    attributes:
+      value: "## Create GitHub Issue for Arcana Dashboard"
+  - type: markdown
+    attributes:
+      value: |
+
+        Make sure to add all the information needed to understand the bug or your feature request.
+
+        If the info is missing we'll add the 'Needs more information' label and prioritize it only when there is enough information provided.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the scenario and the bug.
+      placeholder: Tell us what you see!
+      value: "Something did not work when you tried..."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: Tell us, what did you expect to happen?
+      placeholder: Tell us about the expected behavior!
+      value: "This error should show up or this value should be returned, etc."
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: "## Help us Recreate the Bug"
+  - type: textarea
+    id: steps
+    attributes:
+      label: List the Steps
+      description: Describe how to reproduce the bug step by step.
+      placeholder: Details
+      value: |
+         1. Do this...
+         2. Next do this...
+         3. ...
+    validations:
+        required: true
+  - type: markdown
+    attributes:
+      value: |
+        * Provide screenshots where appropriate
+        * Provide a minimal code snippet / [rnplay](https://rnplay.org/) example that reproduces the bug.
+  - type: textarea
+    id: dev-env
+    attributes:
+      label: Development Environment
+      description: Describe your development environment package version and other details.
+      placeholder: placeholder data
+      value: |
+        * What version of Arcana Dashboard you are using?
+        * If you are using Arcaan Auth SDK for your dApp, mention its Version.
+        * If you are using Arcana Storage SDK, mention its Version.
+        * What's the version of React Native / Vue / JavaScript / TypeScript you're using in your dApp?
+        * Does this issue show up on iOS, Android or both mobileplatforms?
+        * Are you using Mac, Linux or Windows desktop platform?
+        * Which browser / version you were using to access the Dashboard? 
+    validations:
+        required: false
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more information about your bug?
+      placeholder: ex. youremail@youremailprovider.com
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/dashboard_issue.yml
+++ b/.github/ISSUE_TEMPLATE/dashboard_issue.yml
@@ -83,7 +83,7 @@ body:
         * If you are using Arcana Auth SDK for your dApp, mention its Version.
         * If you are using Arcana Storage SDK, mention its Version.
         * What's the version of React Native / Vue / JavaScript / TypeScript you're using in your dApp?
-        * Does this issue show up on iOS, Android or both mobileplatforms?
+        * Does this issue show up on iOS, Android or both mobile platforms?
         * Are you using Mac, Linux or Windows desktop platform?
         * Which browser / version you were using to access the Dashboard? 
     validations:

--- a/.github/ISSUE_TEMPLATE/dashboard_issue.yml
+++ b/.github/ISSUE_TEMPLATE/dashboard_issue.yml
@@ -79,20 +79,12 @@ body:
       description: Describe your development environment package version and other details.
       placeholder: placeholder data
       value: |
-        * What version of Arcana Dashboard you are using?
-        * If you are using Arcana Auth SDK for your dApp, mention its Version.
-        * If you are using Arcana Storage SDK, mention its Version.
-        * What's the version of React Native / Vue / JavaScript / TypeScript you're using in your dApp?
+        * Which browser / version you were using to access the Dashboard? 
         * Does this issue show up on iOS, Android or both mobile platforms?
         * Are you using Mac, Linux or Windows desktop platform?
-        * Which browser / version you were using to access the Dashboard? 
+        * Was browser incognito mode used?
+        * Was access restricted to cookies or local storage in browser settings?
+        * Are there any browser extensions that might interfere?
+        * Mention other details about your dApp tech stack. This includes languages (JavaScript, TypeScript, etc.), frameworks (React, Vue, etc.), or build tools (webpack, rollup, etc.)
     validations:
         required: false
-  - type: input
-    id: contact
-    attributes:
-      label: Contact Details
-      description: How can we get in touch with you if we need more information about your bug?
-      placeholder: ex. youremail@youremailprovider.com
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/dashboard_issue.yml
+++ b/.github/ISSUE_TEMPLATE/dashboard_issue.yml
@@ -80,7 +80,7 @@ body:
       placeholder: placeholder data
       value: |
         * What version of Arcana Dashboard you are using?
-        * If you are using Arcaan Auth SDK for your dApp, mention its Version.
+        * If you are using Arcana Auth SDK for your dApp, mention its Version.
         * If you are using Arcana Storage SDK, mention its Version.
         * What's the version of React Native / Vue / JavaScript / TypeScript you're using in your dApp?
         * Does this issue show up on iOS, Android or both mobileplatforms?


### PR DESCRIPTION
# Pull Request Template

Resolves #AR-3042. GitHub issue template for Dashboard repo

## Blocking dependencies

NA 

## Changes

Includes GitHub config for Arcana Dashboard specific custom template.  
When a GH user clicks on Issue, they will see a form and can fill in requisite fields as part of raising the issue.  None of the suggested inputs / fields are mandatory. User is only allowed to fill up this form as part of issue creation.  We have disabled the option to create a blank issue where user can fill in whatever details they want. It can be enabed using config.yml

Note: This can be tested only when merged in main branch afaik. Also, in Dashboard repo, admin needs to enable "Issues" template in the settings.  I do not have admin rights.  Refer to https://github.com/shaloo/psdemo settings for details.

## Checklist

- [✅  ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [✔️  ] The changes have been tested locally. Cant test as I dont have settings/admin permission.  I tested it for psdemo repo which i own.
