### PR TITLE
Update readme instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,13 +2,19 @@
 
 ## Quick Start
 
-For local developer, start by cloning the repository.
+For local development, start by cloning the repository.
 
 ```
 git clone git@github.com:arcana-network/developer-dashboard.git
 ```
 
-Ensure you have **node** version v16 or higher installed. Install dependencies.
+Move the project directory.
+
+```bash
+cd developer-dashboard
+```
+
+Ensure you have **node** version v16 or higher installed. Install project dependencies.
 
 ```bash
 npm install
@@ -22,10 +28,16 @@ cp .env.example .env
 
 ## Development
 
-Start the development server.
+Start the local development server.
 
 ```bash
 npm run dev
+```
+
+Run all linters and formatters.
+
+```bash
+npm run lint
 ```
 
 Build and generate static files for production.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,47 @@
-# Arcana Developer Dashboard
+<p align="center">
+<a href="#start"><img height="30rem" src="https://raw.githubusercontent.com/arcana-network/branding/main/an_logo_light_temp.png"/></a>
+<h2 align="center"> <a href="https://arcana.network/">Arcana Network Developer Dashboard </a></h2>
+</p>
+<br/>
+<p id="banner" align="center">
+<br/>
+<a title="MIT License" href="https://github.com/arcana-network/license/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue"/></a>
+<a title="Beta release" href="https://github.com/arcana-network/developer-dashboard/releases"><img src="https://img.shields.io/github/v/release/arcana-network/developer-dashboard?style=flat-square&color=28A745"/></a>
+<a title="Twitter" href="https://twitter.com/ArcanaNetwork"><img alt="Twitter URL" src="https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2FArcanaNetwork"/></a>
+</p><p id="start" align="center">
+<a href="https://docs.beta.arcana.network/"><img src="https://raw.githubusercontent.com/arcana-network/branding/main/an_banner_temp.png" alt="Arcana Developer Dashboard"/></a>
+</p>
 
-## Quick Start
+# ⚙️ Arcana Developer Dashboard
+
+Arcana Developer Dashboard allows dApp developers to configure how they choose to integrate and use Arcana SDKs. It is used to tailor the desired dApp user experience for authentication, data privacy, storage access, and monitoring dApp user storage consumption metrics.
+
+# 💪 Key Features
+
+<p>⛓️ &nbsp; Register your dApp with Arcana Network and select storage region for dApp user data</p>
+<p>🔒 &nbsp; Configure social authentication, passwordless login to onboard dApp users</p>
+<p>👛 &nbsp; Specify Storage usage and bandwidth limit per dApp user</p>
+<p>⚙️ &nbsp; Configure transaction signing user experience (no UI, popup UI) as per dApp use case</p>
+
+# 📚 Documentation
+
+Check out [Arcana Network documentation](https://docs.beta.arcana.network/) and refer to [How to Register and Configure dApp Guide](https://docs.beta.arcana.network/docs/config_dapp) for details.
+
+# 💡 Support
+
+For any support or integration related queries, contact [Arcana support team](mailto:support@arcana.network).
+
+# 🤝 Contributing
+
+We welcome all contributions to the Arcana Developer Dashboard from the community. Read our [contributing guide](https://github.com/arcana-network/license/blob/main/CONTRIBUTING.md) to learn about our development process, how to propose bug fixes and improvements, and the code of conduct that we expect the participants to adhere to. Refer to the development section of this readme for details on how to build and validate your changes to the Developer Dashboard code before submitting your contributions.
+
+# ℹ️ License
+
+Arcana Developer Dashboard is distributed under the [MIT License](https://fossa.com/blog/open-source-licenses-101-mit-license/).
+
+For details see [Arcana License](https://github.com/arcana-network/license/blob/main/LICENSE.md).
+
+# 🚀 Development and Setup
 
 For local development, start by cloning the repository.
 
@@ -26,7 +67,7 @@ In the project root, create an `.env` file by copying the content of `.env.examp
 cp .env.example .env
 ```
 
-## Development
+## 🧪 Build and Test
 
 Start the local development server.
 
@@ -52,7 +93,7 @@ Preview the generated site before deploying.
 npm run preview
 ```
 
-## Usage with Docker
+## 🫙 Docker Setup
 
 If you'd like to use [Docker](https://docs.docker.com/engine/install/) to setup the dashboard as a service, follow the above quick start steps and then use
 

--- a/readme.md
+++ b/readme.md
@@ -54,10 +54,10 @@ npm run preview
 
 ## Usage with Docker
 
-If you'd like to use [Docker](https://docs.docker.com/engine/install/) for development, follow the above quick start steps and then use
+If you'd like to use [Docker](https://docs.docker.com/engine/install/) to setup the dashboard as a service, follow the above quick start steps and then use
 
 ```bash
 make run-local
 ```
 
-to spin up a local dashboard serve.
+to spin up the service.

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ For local development, start by cloning the repository.
 git clone git@github.com:arcana-network/developer-dashboard.git
 ```
 
-Move the project directory.
+Move to the project directory.
 
 ```bash
 cd developer-dashboard

--- a/readme.md
+++ b/readme.md
@@ -2,13 +2,19 @@
 
 ## Quick Start
 
-Install dependencies.
+For local developer, start by cloning the repository.
+
+```
+git clone git@github.com:arcana-network/developer-dashboard.git
+```
+
+Ensure you have **node** version v16 or higher installed. Install dependencies.
 
 ```bash
 npm install
 ```
 
-Create `.env` file in root, copy the content of `.env.example`, and fill in the environment variables.
+In the project root, create an `.env` file by copying the content of `.env.example`, and filling in the environment variables.
 
 ```bash
 cp .env.example .env
@@ -16,13 +22,13 @@ cp .env.example .env
 
 ## Development
 
-Run the project in development environment.
+Start the development server.
 
 ```bash
 npm run dev
 ```
 
-Build and generate static files.
+Build and generate static files for production.
 
 ```bash
 npm run build
@@ -31,29 +37,15 @@ npm run build
 Preview the generated site before deploying.
 
 ```bash
-npm run serve
+npm run preview
 ```
 
-## Local environment setup
+## Usage with Docker
 
-#### Prerequisits
+If you'd like to use [Docker](https://docs.docker.com/engine/install/) for development, follow the above quick start steps and then use
 
-- [Docker](https://docs.docker.com/engine/install/)
-
-1. Clone the repository
-
-```
-git clone git@github.com:arcana-network/developer-dashboard.git
-```
-
-2. Create environment file
-
-```
-cp .env.example .env
-```
-
-3. Run local environment with Dashboard service
-
-```
+```bash
 make run-local
 ```
+
+to spin up a local dashboard serve.


### PR DESCRIPTION
- Replace `npm run serve` with `npm run preview` script.
- Clean up and reorganise the readme content.