### PR TITLE
Create signer everytime after fetching app config

### DIFF
--- a/src/components/app-configure/CreateApp.vue
+++ b/src/components/app-configure/CreateApp.vue
@@ -18,6 +18,7 @@ import {
   type Region,
   type StorageRegion,
 } from '@/utils/constants'
+import { createTransactionSigner } from '@/utils/signerUtils'
 
 const appStore = useAppStore()
 const loaderStore = useLoaderStore()
@@ -53,6 +54,7 @@ async function handleCreateApp() {
   appStore.appId = String(app.ID)
 
   await appStore.fetchAppConfig()
+  createTransactionSigner()
   loaderStore.hideLoader()
   router.push({ name: 'GeneralSettings' })
 }

--- a/src/pages/AppConfigure.vue
+++ b/src/pages/AppConfigure.vue
@@ -108,7 +108,6 @@ function handleSmartContractErrors(type: string, error: unknown) {
 
 function handleCancel() {
   appStore.fetchAppConfig()
-  createTransactionSigner()
   router.push({ name: 'Dashboard' })
 }
 </script>

--- a/src/pages/AppConfigure.vue
+++ b/src/pages/AppConfigure.vue
@@ -26,7 +26,6 @@ import {
   type ConfigureTab,
   type ConfigureTabType,
 } from '@/utils/constants'
-import { createTransactionSigner } from '@/utils/signerUtils'
 
 const currentTab: Ref<ConfigureTabType> = ref('general')
 const router = useRouter()

--- a/src/pages/AppConfigure.vue
+++ b/src/pages/AppConfigure.vue
@@ -26,6 +26,7 @@ import {
   type ConfigureTab,
   type ConfigureTabType,
 } from '@/utils/constants'
+import { createTransactionSigner } from '@/utils/signerUtils'
 
 const currentTab: Ref<ConfigureTabType> = ref('general')
 const router = useRouter()
@@ -107,6 +108,7 @@ function handleSmartContractErrors(type: string, error: unknown) {
 
 function handleCancel() {
   appStore.fetchAppConfig()
+  createTransactionSigner()
   router.push({ name: 'Dashboard' })
 }
 </script>


### PR DESCRIPTION
## Changes

- Signer was not getting updated after creating new app. So added `createTransactionSigner`, everytime we do fetch app details

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
