### PR TITLE
Remove redirect uri from social auth

### DIFF
--- a/src/stores/apps.store.ts
+++ b/src/stores/apps.store.ts
@@ -26,7 +26,6 @@ type SocialAuthState = {
   verifier: SocialAuthVerifier
   clientId?: string
   clientSecret?: string
-  redirectUri?: string
 }
 
 type Theme = 'light' | 'dark'
@@ -186,7 +185,6 @@ const useAppsStore = defineStore('apps', {
               verifier: authDetail.verifier,
               clientId: authDetail.clientId,
               clientSecret: authDetail.clientSecret,
-              redirectUri: authDetail.redirectUrl,
             })
           } else {
             passwordlessAuth.javascriptOrigin = authDetail.origin || ''

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -129,7 +129,6 @@ type SocialAuthOption = {
   name: SocialAuthVerifierLabel
   verifier: SocialAuthVerifier
   hasClientSecret: boolean
-  hasRedirectUri: boolean
   documentation: string
 }
 
@@ -138,28 +137,24 @@ const socialLogins: readonly SocialAuthOption[] = [
     name: 'Google',
     verifier: 'google',
     hasClientSecret: false,
-    hasRedirectUri: false,
     documentation: 'https://developers.google.com/identity/sign-in/web/sign-in',
   },
   {
     name: 'Twitch',
     verifier: 'twitch',
     hasClientSecret: false,
-    hasRedirectUri: false,
     documentation: 'https://dev.twitch.tv/docs/authentication#registration',
   },
   {
     name: 'Discord',
     verifier: 'discord',
     hasClientSecret: true,
-    hasRedirectUri: false,
     documentation: 'https://discord.com/developers/applications',
   },
   {
     name: 'GitHub',
     verifier: 'github',
     hasClientSecret: true,
-    hasRedirectUri: false,
     documentation:
       'https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app',
   },
@@ -167,7 +162,6 @@ const socialLogins: readonly SocialAuthOption[] = [
     name: 'Twitter',
     verifier: 'twitter',
     hasClientSecret: true,
-    hasRedirectUri: true,
     documentation: 'https://developer.twitter.com/en/docs/apps/overview',
   },
 ]


### PR DESCRIPTION
Resolves [AR-4516](https://team-1624093970686.atlassian.net/browse/AR-4516).

## Changes

- Removed redirectUri from social auth as it is not required anymore. Previously it was required for twitter login

## Screenshots
Before
![Screenshot from 2022-10-04 11-30-09](https://user-images.githubusercontent.com/24249988/193746056-a8ebae21-3dc0-4348-9ed2-c3393b3a5e00.png)

After
![Screenshot from 2022-10-04 11-30-26](https://user-images.githubusercontent.com/24249988/193746036-3ac3a95c-be3b-41e1-b6ec-74b79fc16a9b.png)


## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
