### PR TITLE
Hotfix for AR-4808 - Copy app address instead of app id

### DIFF
--- a/src/pages/AppDashboard.vue
+++ b/src/pages/AppDashboard.vue
@@ -276,12 +276,12 @@ function goToConfigure() {
 const SmartContractIcon = ref(CopyIcon)
 const smartContractTooltip = ref('Click to copy')
 
-async function copyAppId() {
+async function copyAppAddress() {
   try {
     SmartContractIcon.value = CheckIcon
     smartContractTooltip.value = 'Copied'
-    await copyToClipboard(String(appId))
-    toast.success('App ID copied')
+    await copyToClipboard(appAddress)
+    toast.success('App address copied')
   } catch (e) {
     console.error(e)
     toast.error('Failed to copy. Try again or contact support')
@@ -350,7 +350,7 @@ watch(
           <v-tooltip
             :title="smartContractTooltip"
             class="mobile-remove"
-            @click.stop="copyAppId"
+            @click.stop="copyAppAddress"
           >
             <img
               :src="SmartContractIcon"
@@ -401,7 +401,7 @@ watch(
         <v-tooltip
           :title="smartContractTooltip"
           class=""
-          @click.stop="copyAppId"
+          @click.stop="copyAppAddress"
         >
           <img
             :src="SmartContractIcon"


### PR DESCRIPTION
Hotfix for [AR-4808](https://team-1624093970686.atlassian.net/browse/AR-4808)

## Changes

Copy app address instead of app id

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
