### PR TITLE
AR-5108 Show key name instead of address on key dropdown

### DIFF
--- a/src/components/app-configure/access/CreateOrEditDelegate.vue
+++ b/src/components/app-configure/access/CreateOrEditDelegate.vue
@@ -49,8 +49,11 @@ const appsStore = useAppsStore()
 onMounted(() => {
   if (props.variant === 'edit' && props.delegateInfo) {
     delegateName.value = props.delegateInfo.name
+    const keyName = delegateKeysList.value.find(
+      (key) => key.address === props.delegateInfo?.address
+    )?.name
     selectedDelegateKey.value = {
-      name: props.delegateInfo.address,
+      name: keyName || props.delegateInfo.address,
       address: props.delegateInfo.address,
     }
   }
@@ -295,6 +298,7 @@ function handleGenerateKey() {
   max-width: 12ch;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .custom-option {


### PR DESCRIPTION
Resolves [AR-5108](https://team-1624093970686.atlassian.net/browse/AR-5108).

## Changes

- Show key name instead of address on select key dropdown
- Add whitespace nowrap to dropdown input so it doesn't wrap to next line on overflow

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
