### PR TITLE
[HOTFIX] - Use "connect" event to wait until wallet provider is connected

### DIFF
--- a/src/pages/AppLogin.vue
+++ b/src/pages/AppLogin.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { onMounted, ref, computed } from '@vue/runtime-core'
+import { onMounted, ref, computed } from 'vue'
 import { useRoute, useRouter, type RouteRecordName } from 'vue-router'
 
 import AppFooter from '@/components/AppFooter.vue'
@@ -99,10 +99,11 @@ async function fetchAndStoreUserInfo() {
 
 onMounted(async () => {
   if (await arcanaAuth.isLoggedIn()) {
-    loaderStore.showLoader('Signing In...')
-    setTimeout(async () => {
+    loaderStore.showLoader('Connecting wallet...')
+    arcanaAuth.getProvider().on('connect', async () => {
+      loaderStore.showLoader('Signing in...')
       await fetchAndStoreDetails()
-    }, 1000)
+    })
   }
 })
 </script>

--- a/src/use/arcanaAuth.ts
+++ b/src/use/arcanaAuth.ts
@@ -26,11 +26,7 @@ function useArcanaAuth() {
   async function init() {
     if (!authInstance) {
       authInstance = new AuthProvider(ARCANA_APP_ADDRESS, {
-        network: {
-          authUrl: 'http://localhost:8080',
-          gatewayUrl: 'https://gateway-dev.arcana.network',
-          walletUrl: 'http://localhost:3000',
-        },
+        network,
         debug: true,
         chainConfig: {
           chainId: CHAIN.POLYGON_MAINNET,

--- a/src/use/arcanaAuth.ts
+++ b/src/use/arcanaAuth.ts
@@ -6,7 +6,7 @@ const { AuthProvider, CHAIN } = window.arcana.auth
 const ARCANA_APP_ADDRESS = import.meta.env.VITE_ARCANA_APP_ADDRESS
 const ARCANA_AUTH_NETWORK = import.meta.env.VITE_ARCANA_AUTH_NETWORK
 
-let authInstance: AuthProvider
+let authInstance: typeof AuthProvider
 let network: 'testnet' | 'mainnet' | any
 
 if (ARCANA_AUTH_NETWORK === 'mainnet') {
@@ -26,7 +26,11 @@ function useArcanaAuth() {
   async function init() {
     if (!authInstance) {
       authInstance = new AuthProvider(ARCANA_APP_ADDRESS, {
-        network,
+        network: {
+          authUrl: 'http://localhost:8080',
+          gatewayUrl: 'https://gateway-dev.arcana.network',
+          walletUrl: 'http://localhost:3000',
+        },
         debug: true,
         chainConfig: {
           chainId: CHAIN.POLYGON_MAINNET,
@@ -67,6 +71,10 @@ function useArcanaAuth() {
     return await authInstance.getPublicKey(email)
   }
 
+  function getProvider() {
+    return authInstance.provider
+  }
+
   return {
     init,
     isLoggedIn,
@@ -75,6 +83,7 @@ function useArcanaAuth() {
     logout,
     fetchUserDetails,
     getPublicKey,
+    getProvider,
   }
 }
 


### PR DESCRIPTION
## Changes

- Use "connect" event to wait until wallet provider is connected, else fetching user details from wallet fails as wallet is not connected

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
