### PR TITLE
[AR-5832] Separate out dev testnet mainnet

### DIFF
--- a/src/components/MainnetAppCreatedPopup.vue
+++ b/src/components/MainnetAppCreatedPopup.vue
@@ -5,6 +5,7 @@ import VButton from '@/components/lib/VButton/VButton.vue'
 import VCard from '@/components/lib/VCard/VCard.vue'
 import VOverlay from '@/components/lib/VOverlay/VOverlay.vue'
 import type { AppId } from '@/stores/apps.store'
+import { NetworkName } from '@/utils/constants'
 
 type Props = {
   appId: AppId
@@ -25,10 +26,10 @@ function handleMainnetKeySpace() {
     <div class="popup-container">
       <VCard class="popup-card">
         <img src="@/assets/success-celebrate.svg" style="width: 8rem" />
-        <h3 class="popup-title">Mainnet App Created!</h3>
+        <h3 class="popup-title">{{ NetworkName.mainnet }} App Created!</h3>
         <span class="popup-message">
-          Mainnet app has been configured. <br />Please proceed to configure
-          your app's keyspace
+          {{ NetworkName.mainnet }} app has been configured. <br />Please
+          proceed to configure your app's keyspace
         </span>
         <VButton
           label="CONFIGURE KEYSPACE"

--- a/src/components/SwitchToMainnetConfirmation.vue
+++ b/src/components/SwitchToMainnetConfirmation.vue
@@ -4,16 +4,17 @@ import { ref } from 'vue'
 import VButton from '@/components/lib/VButton/VButton.vue'
 import VOverlay from '@/components/lib/VOverlay/VOverlay.vue'
 import VRadio from '@/components/lib/VRadio/VRadio.vue'
+import { NetworkName } from '@/utils/constants'
 
 const emits = defineEmits(['cancel', 'proceed'])
 
 const mainnetCopyOptions = [
   {
-    label: 'Copy Existing Testnet Config',
+    label: `Copy Existing ${NetworkName.testnet} Config`,
     value: 0,
   },
   {
-    label: 'New Mainnet Config',
+    label: `New ${NetworkName.mainnet} Config`,
     value: 1,
   },
 ]
@@ -30,11 +31,14 @@ function onProceed() {
   <VOverlay>
     <div class="switch-chain__outer-container">
       <div class="switch-chain__container">
-        <h3 class="switch-chain__title">Switch to Mainnet?</h3>
+        <h3 class="switch-chain__title">
+          Switch to {{ NetworkName.mainnet }}?
+        </h3>
         <p class="switch-chain__message">
-          To create Mainnet configuration profile you can copy Testnet
-          application settings profile or create a fresh Mainnet configuration.
-          Each configuration profile is assigned a unique App Address.
+          To create {{ NetworkName.mainnet }} configuration profile you can copy
+          {{ NetworkName.testnet }} application settings profile or create a
+          fresh {{ NetworkName.mainnet }} configuration. Each configuration
+          profile is assigned a unique App Address.
         </p>
         <div class="flex switch-chain__copy-optionss">
           <div

--- a/src/components/app-configure/ConfigureSidebar.vue
+++ b/src/components/app-configure/ConfigureSidebar.vue
@@ -88,15 +88,15 @@ const ConfigureTabs = computed(() => {
   const configurePageIndex = configureTabsCopy.findIndex(
     (tab) => tab.type === 'configure'
   )
-  if (props.currentNetwork === 'mainnet') {
-    configureTabsCopy[configurePageIndex]?.subMenu?.push({
-      label: 'Keyspace',
-      type: 'keyspace',
-      icon: KeyspaceIcon,
-    })
-    return configureTabsCopy
-  }
+  // if (props.currentNetwork === 'mainnet') {
+  configureTabsCopy[configurePageIndex]?.subMenu?.push({
+    label: 'Keyspace',
+    type: 'keyspace',
+    icon: KeyspaceIcon,
+  })
   return configureTabsCopy
+  // }
+  // return configureTabsCopy
 })
 
 function onClickOfMenu(tab: ConfigureTab) {

--- a/src/components/app-configure/VerificationForm.vue
+++ b/src/components/app-configure/VerificationForm.vue
@@ -184,9 +184,12 @@ async function handleSubmit() {
             <VStack
               gap="1.25rem"
               style="justify-content: center; margin-block: 2rem"
-              @click.stop="emit('close')"
             >
-              <VButton variant="secondary" label="CANCEL"></VButton>
+              <VButton
+                variant="secondary"
+                label="CANCEL"
+                @click.stop="emit('close')"
+              ></VButton>
               <VButton type="submit" label="SUBMIT"></VButton>
             </VStack>
           </form>

--- a/src/components/app-configure/VerificationForm.vue
+++ b/src/components/app-configure/VerificationForm.vue
@@ -12,6 +12,7 @@ import { useToast } from '@/components/lib/VToast'
 import { submitVerificationForm } from '@/services/gateway.service'
 import type { AppId } from '@/stores/apps.store'
 import { useLoaderStore } from '@/stores/loader.store'
+import { NetworkName } from '@/utils/constants'
 import { isValidEmail } from '@/utils/validation'
 
 type VerificationFormProps = {
@@ -107,7 +108,8 @@ async function handleSubmit() {
           <h3 class="verification-title">Verification Form</h3>
           <div class="verification-description" style="text-align: center">
             Fill up this verification form to register your application on
-            Mainnet and enable the Global keys feature. For assistance,&nbsp;
+            {{ NetworkName.mainnet }} and enable the Global keys feature. For
+            assistance,&nbsp;
             <a href="mailto:support@arcana.network">contact support</a>.
           </div>
           <form @submit.prevent="handleSubmit">

--- a/src/components/app-configure/VerificationForm.vue
+++ b/src/components/app-configure/VerificationForm.vue
@@ -10,7 +10,7 @@ import VStack from '@/components/lib/VStack/VStack.vue'
 import VTextField from '@/components/lib/VTextField/VTextField.vue'
 import { useToast } from '@/components/lib/VToast'
 import { submitVerificationForm } from '@/services/gateway.service'
-import type { AppId } from '@/stores/apps.store'
+import { useAppsStore, type AppId } from '@/stores/apps.store'
 import { useLoaderStore } from '@/stores/loader.store'
 import { NetworkName } from '@/utils/constants'
 import { isValidEmail } from '@/utils/validation'
@@ -25,6 +25,7 @@ const emit = defineEmits(['close', 'submitted'])
 const toast = useToast()
 const loaderStore = useLoaderStore()
 const error = ref('')
+const appsStore = useAppsStore()
 
 const formData = reactive({
   companyName: '',
@@ -70,7 +71,8 @@ async function handleSubmit() {
   }
   loaderStore.showLoader('Submitting the form for verification...')
   try {
-    await submitVerificationForm(props.appId, {
+    const app = appsStore.app(props.appId)
+    await submitVerificationForm(app.network, {
       app: props.address,
       company_name: formData.companyName,
       project_name: formData.projectName,

--- a/src/pages/AppDashboard.vue
+++ b/src/pages/AppDashboard.vue
@@ -58,7 +58,7 @@ const selectedApp = computed(() => appsStore.app(appId.value))
 const appAddress = computed(() => {
   let clientId = 'xar_'
   if (selectedApp.value.network === 'mainnet') {
-    clientId += 'live_'
+    clientId += ARCANA_AUTH_NETWORK === 'dev' ? 'test_' : 'live_'
   } else {
     clientId += ARCANA_AUTH_NETWORK === 'dev' ? 'dev_' : 'test_'
   }

--- a/src/pages/AppDetails.vue
+++ b/src/pages/AppDetails.vue
@@ -30,17 +30,18 @@ import {
   type Network,
   regions,
   RegionMapping,
+  NetworkName,
 } from '@/utils/constants'
 import { createAppConfig } from '@/utils/createAppConfig'
 import { createTransactionSigner } from '@/utils/signerUtils'
 
 const NetworkOptions = [
   {
-    label: 'Testnet',
+    label: NetworkName.testnet,
     value: 'testnet',
   },
   {
-    label: 'Mainnet',
+    label: NetworkName.mainnet,
     value: 'mainnet',
   },
 ]
@@ -183,7 +184,7 @@ async function handleCreateMainnetApp({
     testnetApp.global_id = updatedTestnetApp.global_id
     await appsStore.fetchAndStoreAppConfig(updatedTestnetApp?.ID, 'testnet')
 
-    toast.success('Mainnet app created')
+    toast.success(`${NetworkName.mainnet} app created`)
     if (mainnetApp) {
       showMainnetConfirmation.value = false
       createdMainnetAppId.value = mainnetApp.ID

--- a/src/pages/ManageApps.vue
+++ b/src/pages/ManageApps.vue
@@ -24,6 +24,7 @@ import {
 } from '@/services/gateway.service'
 import { useAppsStore, type AppConfig, type AppId } from '@/stores/apps.store'
 import type { Network } from '@/utils/constants'
+import { NetworkName } from '@/utils/constants'
 
 const router = useRouter()
 const appsStore = useAppsStore()
@@ -275,7 +276,9 @@ async function handleAppNameSave(app: AppData) {
               </VStack>
               <VCard variant="depressed" gap="6px" class="stats-card">
                 <VStack direction="column" align="center" gap="0.25rem">
-                  <span class="stats-title">Testnet Users</span>
+                  <span class="stats-title"
+                    >{{ NetworkName.testnet }} Users</span
+                  >
                   <span class="stats-number">{{ app.totalUsers || 0 }}</span>
                 </VStack>
                 <VSeperator
@@ -289,7 +292,9 @@ async function handleAppNameSave(app: AppData) {
                   align="center"
                   gap="0.25rem"
                 >
-                  <span class="stats-title">Mainnet Users</span>
+                  <span class="stats-title"
+                    >{{ NetworkName.mainnet }} Users</span
+                  >
                   <span class="stats-number">{{
                     getMainnetTotalUsers(app.id)
                   }}</span>
@@ -298,14 +303,14 @@ async function handleAppNameSave(app: AppData) {
               <VStack gap="1rem" style="width: 100%; margin-top: 0.5rem">
                 <VButton
                   variant="secondary"
-                  label="Testnet"
+                  :label="NetworkName.testnet"
                   class="app-action-button delete-button"
                   :disabled="app.network !== 'testnet'"
                   @click.stop="() => goToDashboard(app.id, 'testnet')"
                 />
                 <VButton
                   variant="primary"
-                  label="Mainnet"
+                  :label="NetworkName.mainnet"
                   class="app-action-button pause-button"
                   :disabled="!isMainnetAppAvailable(app.id)"
                   @click.stop="() => goToDashboard(app.id, 'mainnet')"

--- a/src/services/gateway.service.ts
+++ b/src/services/gateway.service.ts
@@ -442,10 +442,10 @@ function getAccountStatus(): Promise<AxiosResponse<AccountStatus>> {
 }
 
 function submitVerificationForm(
-  appId: AppId,
+  network: Network,
   formData: any
 ): Promise<AxiosResponse<any>> {
-  return getGatewayInstance('mainnet').post(`${getEnvApi()}/verify-app/`, {
+  return getGatewayInstance(network).post(`${getEnvApi()}/verify-app/`, {
     ...formData,
   })
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -36,6 +36,13 @@ const api = {
 }
 
 const isAppDown: boolean = import.meta.env.VITE_IS_APP_DOWN || false
+const isProductionDashboard: boolean =
+  import.meta.env.VITE_ARCANA_AUTH_NETWORK === 'mainnet'
+
+const NetworkName = {
+  testnet: isProductionDashboard ? 'Testnet' : 'Dev',
+  mainnet: isProductionDashboard ? 'Mainnet' : 'Testnet',
+}
 
 const DOCS_URL: string = import.meta.env.VITE_ARCANA_DOCS_URL
 
@@ -304,6 +311,8 @@ export {
   WalletMode,
   MAX_DATA_TRANSFER_BYTES,
   DOCS_URL,
+  isProductionDashboard,
+  NetworkName,
   HelpItems,
   ProfileItems,
 }


### PR DESCRIPTION
Resolves [AR-5832](https://team-1624093970686.atlassian.net/browse/AR-5832).

## Changes

- Separate out dev, testnet, and mainnet in the dashboard where 
   - Dev environment will have `dev` and `testnet`
   - Prod environment will have `testnet` and `mainnet`
- Switching the keyspace will also be available in `dev` and `testnet`. Previously it was only available in `mainnet`

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.


[AR-5832]: https://team-1624093970686.atlassian.net/browse/AR-5832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ