### PR TITLE
[AR-5945] show notification time as relative time

### DIFF
--- a/src/components/AppNotifications.vue
+++ b/src/components/AppNotifications.vue
@@ -46,6 +46,13 @@ async function markNotificationAsRead() {
 function toggleNotifications() {
   emits('close')
 }
+
+function getNotificationsTime(timeStamp) {
+  const isToday = moment(timeStamp).isSame(new Date(), 'day')
+  return isToday
+    ? moment(timeStamp).format('hh:mm a')
+    : moment(timeStamp).fromNow()
+}
 </script>
 
 <template>
@@ -67,7 +74,7 @@ function toggleNotifications() {
                 {{ notification.Data }}
               </p>
               <p class="notification-item__time">
-                {{ moment(notification.Time).fromNow() }}
+                {{ getNotificationsTime(notification.Time) }}
               </p>
             </li>
           </ul>
@@ -101,7 +108,7 @@ function toggleNotifications() {
                 {{ notification.Data }}
               </p>
               <p class="notification-item__time">
-                {{ moment(notification.Time).fromNow() }}
+                {{ getNotificationsTime(notification.Time) }}
               </p>
             </li>
           </ul>

--- a/src/components/AppNotifications.vue
+++ b/src/components/AppNotifications.vue
@@ -25,7 +25,8 @@ async function fetchNotifications() {
     const { notification, latest_notification_id } = (await getNotifications())
       .data
     notifications.value = notification
-    if (notification.length) appsStore.areNotificationAvaiable = true
+    if (Array.isArray(notification) && notification.length)
+      appsStore.areNotificationAvaiable = true
     latestNotificationId.value = latest_notification_id
   } catch (e) {
     console.error(e)

--- a/src/components/AppNotifications.vue
+++ b/src/components/AppNotifications.vue
@@ -20,17 +20,26 @@ onMounted(fetchNotifications)
 onUnmounted(markNotificationAsRead)
 
 async function fetchNotifications() {
-  showLoader.value = true
-  const { notification, latest_notification_id } = (await getNotifications())
-    .data
-  notifications.value = notification
-  if (notification.length) appsStore.areNotificationAvaiable = true
-  latestNotificationId.value = latest_notification_id
-  showLoader.value = false
+  try {
+    showLoader.value = true
+    const { notification, latest_notification_id } = (await getNotifications())
+      .data
+    notifications.value = notification
+    if (notification.length) appsStore.areNotificationAvaiable = true
+    latestNotificationId.value = latest_notification_id
+  } catch (e) {
+    console.error(e)
+  } finally {
+    showLoader.value = false
+  }
 }
 
 async function markNotificationAsRead() {
-  await updateNotificationRead(latestNotificationId.value)
+  try {
+    await updateNotificationRead(latestNotificationId.value)
+  } catch (e) {
+    console.error(e)
+  }
 }
 
 function toggleNotifications() {

--- a/src/components/AppNotifications.vue
+++ b/src/components/AppNotifications.vue
@@ -67,7 +67,7 @@ function toggleNotifications() {
                 {{ notification.Data }}
               </p>
               <p class="notification-item__time">
-                {{ moment(notification.Time).format('ddd-MMM, h:mm:ss a') }}
+                {{ moment(notification.Time).fromNow() }}
               </p>
             </li>
           </ul>
@@ -101,7 +101,7 @@ function toggleNotifications() {
                 {{ notification.Data }}
               </p>
               <p class="notification-item__time">
-                {{ moment(notification.Time).format('ddd-MMM, h:mm:ss a') }}
+                {{ moment(notification.Time).fromNow() }}
               </p>
             </li>
           </ul>


### PR DESCRIPTION
# Pull Request

Resolves or continues [AR-5945](https://team-1624093970686.atlassian.net/browse/AR-5945).

## Changes

1. Show timestamp of notifications in relative time (Eg: 4 days ago, 1 second ago).


## Checklist

- [X] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [X] The changes have been tested locally.


[AR-5945]: https://team-1624093970686.atlassian.net/browse/AR-5945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ