### PR TITLE
Hide adding card details if billing address is not present in the server

### DIFF
--- a/src/pages/AppProfile.vue
+++ b/src/pages/AppProfile.vue
@@ -559,9 +559,15 @@ function handleCancel() {
         </SettingCard>
       </section>
       <section style="margin-top: 3em">
-        <SettingCard>
+        <SettingCard style="overflow: hidden">
           <template #title>PAYMENT METHODS</template>
-          <form @submit.prevent="submitCard">
+          <form
+            class="payment-form"
+            :class="{
+              'hide-payment-form': !billingDetails.isPresentInServer,
+            }"
+            @submit.prevent="submitCard"
+          >
             <VStack
               class="flex sm-column flex-wrap justify-space-between payment-container"
               gap="0.5rem"
@@ -753,6 +759,25 @@ label {
 
 .billing-details {
   display: flex;
+}
+
+.payment-form {
+  position: relative;
+}
+
+.hide-payment-form::before {
+  position: absolute;
+  inset: -2rem -1.5rem;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  font-family: var(--font-body);
+  text-align: center;
+  content: 'Enter the billing address details to access payment methods.';
+  background: rgb(10 10 10 / 70%);
+  backdrop-filter: blur(16px);
 }
 
 @media only screen and (max-width: 1023px) {


### PR DESCRIPTION
## Changes

- Mask adding card details if the billing address is not present.

## Screenshots

Before

![Screenshot from 2023-04-10 11-43-19](https://user-images.githubusercontent.com/24249988/230838866-42f0af84-f38d-4677-826a-1903f4647a8f.png)

After

![Screenshot from 2023-04-10 11-43-29](https://user-images.githubusercontent.com/24249988/230838861-313d7ac1-408f-4a33-809f-7344a806a8db.png)


## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
