### PR TITLE
[Bug] add client Id only for Steam is selected

### DIFF
--- a/src/components/app-configure/auth/SocialAuth.vue
+++ b/src/components/app-configure/auth/SocialAuth.vue
@@ -87,7 +87,11 @@ async function handleSave() {
     const { auth } = app
     const social = socialAuthRef
       .map((authRef) => {
-        if (authRef.verifier === 'steam') authRef.clientId = app.address
+        if (
+          authRef.verifier === 'steam' &&
+          selectedCredentialInput.value === 'steam'
+        )
+          authRef.clientId = app.address
         const { verifier, clientId, clientSecret } = authRef
         return { verifier, clientId, clientSecret }
       })


### PR DESCRIPTION
# Pull Request

## Changes
Bug: **Steam** client Id is uploaded even without selecting its tab.
Fix: Check if **Steam** tab is selected before adding app address.

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [X] The changes have been tested locally.
